### PR TITLE
Add Tableau and Power BI Comparison

### DIFF
--- a/dendron.yml
+++ b/dendron.yml
@@ -75,7 +75,7 @@ preview:
     automaticallyShowPreview: false
 publishing:
     assetsPrefix: /set-notegraph
-    siteUrl: https://CUHealthAI.github.io
+    siteUrl: https://CU-DBMI.github.io
     enableFMTitle: true
     enableNoteTitleForLink: true
     enableMermaid: true

--- a/vault/tools.data-visualization.md
+++ b/vault/tools.data-visualization.md
@@ -2,7 +2,7 @@
 id: fhpqcia6cfvjdt6yjulbs0v
 title: Data Visualization
 desc: ''
-updated: 1661454343385
+updated: 1667490344810
 created: 1661442101759
 ---
 
@@ -17,7 +17,7 @@ Covering data visualization tools along with some notes. Items are provided in n
   - Access provided to CU users via UIS: <https://www.cu.edu/uis/service-catalog/tableau>
   - Note distinction between desktop and server, server: private vs public access.
   - Desktop client typically used to create data sources used by server dashboards.
-- [Google Data Studio](https://developers.google.com/datastudio/)
+- [Google Looker Studio](https://developers.google.com/looker-studio)
   - Browser-based tool for creating reports and dashboards.
 - [Google Charts](https://developers.google.com/chart/)
 - [Apache Superset](https://superset.apache.org/)

--- a/vault/tools.data-visualization.tableau-and-powerbi-comparison.md
+++ b/vault/tools.data-visualization.tableau-and-powerbi-comparison.md
@@ -2,7 +2,7 @@
 id: urgb7nmksr3izpnx82iuoxu
 title: Tableau and Power BI Comparison
 desc: ''
-updated: 1667490378330
+updated: 1668120482024
 created: 1667486780981
 ---
 
@@ -54,6 +54,10 @@ Data visualization tools often include their own programming languages which hel
 
 - Tableau Level of Detail (LOD): <https://help.tableau.com/current/pro/desktop/en-us/calculations_calculatedfields_lod.htm>
 - Power BI Data Analysis Expressions (DAX): <https://learn.microsoft.com/en-us/dax/>
+
+## Further Reading
+
+- [Tableau.com | Compare Tableau to Microsoft Power BI](https://www.tableau.com/compare/tableau-power-bi)
 
 ## Other Alternatives
 

--- a/vault/tools.data-visualization.tableau-and-powerbi-comparison.md
+++ b/vault/tools.data-visualization.tableau-and-powerbi-comparison.md
@@ -1,0 +1,63 @@
+---
+id: urgb7nmksr3izpnx82iuoxu
+title: Tableau and Power BI Comparison
+desc: ''
+updated: 1667486875132
+created: 1667486780981
+---
+
+Comparisons between Salesforce Tableau and Microsoft Power BI as data visualization tools.
+
+## Key Questions
+
+There are several key questions to consider when making decisions around data visualization tools. Keep these in mind with the following comparisons and references.
+
+- How are existing skillsets in alignment with the selected tools?
+- What skillsets are desired in future workforce resources?
+- What internal communities are already making use of the selected tools?
+- How do data sources align with visualization tool support? (Layers between data sources and tools may add otherwise hidden complexity and time costs.)
+
+## Feature Comparisons
+
+| Feature | Power BI  | Tableau  |
+| --- | --- | --- |
+| Vendor Support |✅ [ref](https://powerbi.microsoft.com/en-us/support/pro/)  | ✅ [ref](https://www.cu.edu/uis/service-catalog/tableau/support) |
+| CU System Support | ❌  | ✅ [ref](https://www.cu.edu/uis/service-catalog/tableau/support)|
+| Windows Compatibility (Desktop) | ✅ [ref](https://www.microsoft.com/en-us/download/details.aspx?id=58494) | ✅ [ref](https://www.tableau.com/products/techspecs)|
+| MacOS Compatibility (Desktop) | ❌ [ref](https://www.microsoft.com/en-us/download/details.aspx?id=58494) | ✅ [ref](https://www.tableau.com/products/techspecs) |
+
+## Pricing
+
+The following are public-facing pricing details.
+__Enterprise-based pricing may differ__.
+
+- Power BI: <https://powerbi.microsoft.com/en-us/pricing/>
+- Tableau: <https://www.tableau.com/pricing/teams-orgs>
+
+## Data Sources
+
+Data sources which may be connected to the tools.
+
+- Power BI: <https://learn.microsoft.com/en-us/power-bi/connect-data/power-bi-data-sources>
+- Tableau: <https://help.tableau.com/current/pro/desktop/en-us/exampleconnections_overview.htm>
+
+## Visualization Type Support
+
+Visualization types which are supported by the tools.
+
+- Power BI: <https://learn.microsoft.com/en-us/power-bi/visuals/power-bi-visualization-types-for-reports-and-q-and-a>
+- Tableau: <https://help.tableau.com/current/pro/desktop/en-us/what_chart_example.htm>
+
+## Programming Languages
+
+Data visualization tools often include their own programming languages which help to specify detailed work which may be necessary beyond drag-and-drop defaults.
+
+- Tableau Level of Detail (LOD): <https://help.tableau.com/current/pro/desktop/en-us/calculations_calculatedfields_lod.htm>
+- Power BI Data Analysis Expressions (DAX): <https://learn.microsoft.com/en-us/dax/>
+
+## Other Alternatives
+
+- Google Data Studio: <https://lookerstudio.google.com/overview>
+An all-online data visualization suite which integrates with Google and many other sources.
+- Apache Superset: <https://superset.apache.org/>
+An open-source data visualization tool supported by the Apache Software Foundation.

--- a/vault/tools.data-visualization.tableau-and-powerbi-comparison.md
+++ b/vault/tools.data-visualization.tableau-and-powerbi-comparison.md
@@ -2,7 +2,7 @@
 id: urgb7nmksr3izpnx82iuoxu
 title: Tableau and Power BI Comparison
 desc: ''
-updated: 1667486875132
+updated: 1667490378330
 created: 1667486780981
 ---
 
@@ -57,7 +57,7 @@ Data visualization tools often include their own programming languages which hel
 
 ## Other Alternatives
 
-- Google Data Studio: <https://lookerstudio.google.com/overview>
+- Google Looker Studio: <https://lookerstudio.google.com/overview>
 An all-online data visualization suite which integrates with Google and many other sources.
 - Apache Superset: <https://superset.apache.org/>
 An open-source data visualization tool supported by the Apache Software Foundation.


### PR DESCRIPTION
Adding content surrounding the comparison of Tableau and Power BI. My focus was to try and be as non-biased as I could while targeting only these two tools as asked. I found that, as far as what's advertised, there is a lot of technical parity between these tools and their platforms (besides Windows-only compatibility with Power BI Desktop). I tried to present major areas of non-technical information with links per tool in dedicated sections.

My impression is that it matters much more how these tools will be supported (both by internal resources as well as technical support for the platforms themselves) and who will be implementing the visualizations (both now and in the future). I tried to highlight this concern within the key questions section.

In case it's helpful for this or future conversations, I also added an alternatives section that includes two other large software competitors to Tableau and Power BI: Google Looker Studio and Apache Superset.

Aside: `dendron.yml` was also modified to account for Github organization name changes which have occurred since the last time this repository was edited.